### PR TITLE
fix: 修复存在jitter时包组延迟计算异常

### DIFF
--- a/estimator/inter_arrival.c
+++ b/estimator/inter_arrival.c
@@ -65,6 +65,8 @@ static int inter_arrival_new_group(inter_arrival_t* arr, uint32_t ts, int64_t ar
 	uint32_t diff;
 	if (arr->cur_ts_group.complete_ts == -1)
 		return -1;
+	else if (arr->cur_ts_group.timestamp >= ts)
+		return -1;
 	else if (belongs_to_burst(arr, ts, arrival_ts) == 0)
 		return -1;
 	else{


### PR DESCRIPTION
修复存在jitter时可能会导致包组延迟计算中timestamp_delta为负值，整个计算结果异常。
#71 